### PR TITLE
compose: introduce per-container `metrics_port` and `metrics_path`

### DIFF
--- a/2024/2024-10-28--LGTM_stack/compose.jsonnet
+++ b/2024/2024-10-28--LGTM_stack/compose.jsonnet
@@ -14,7 +14,7 @@ local manifest = compose.new({
   prometheus:
     c.prometheus.new()
     + c.prometheus.withVolume()
-    + c.prometheus.withTargets([root.prometheus, root.loki, root.promtail, root.grafana, root.tempo])
+    + c.prometheus.withTargets(std.objectValues(root))
     + c.prometheus.withRemoteWrite([root.mimir], { 'X-Scope-OrgID': mimirConf.orgId }),
   loki:
     c.loki.new()

--- a/2024/2024-10-28--LGTM_stack/docker-compose.configs.yml
+++ b/2024/2024-10-28--LGTM_stack/docker-compose.configs.yml
@@ -145,26 +145,31 @@ configs:
           X-Scope-OrgID: "demo"
         url: "http://mimir:8080/api/v1/push"
       scrape_configs:
-      - job_name: "prometheus"
-        static_configs:
-        - targets:
-          - "prometheus:9090"
-      - job_name: "loki"
-        static_configs:
-        - targets:
-          - "loki:3100"
-      - job_name: "promtail"
-        static_configs:
-        - targets:
-          - "promtail:9080"
       - job_name: "grafana"
         static_configs:
         - targets:
           - "grafana:3000"
-      - job_name: "tempo"
+      - job_name: "loki"
         static_configs:
         - targets:
-          - "tempo:3200"
+          - "loki:3100"
+      - job_name: "mimir"
+        static_configs:
+        - targets:
+          - "mimir:8080"
+      - job_name: "minio"
+        metrics_path: "/minio/v2/metrics/bucket"
+        static_configs:
+        - targets:
+          - "minio:9000"
+      - job_name: "prometheus"
+        static_configs:
+        - targets:
+          - "prometheus:9090"
+      - job_name: "promtail"
+        static_configs:
+        - targets:
+          - "promtail:9080"
   promtail_config:
     content: |-
       clients:

--- a/2024/2024-10-28--LGTM_stack/docker-compose.yml
+++ b/2024/2024-10-28--LGTM_stack/docker-compose.yml
@@ -63,6 +63,7 @@ services:
     entrypoint:
       - ""
     environment:
+      - MINIO_PROMETHEUS_AUTH_TYPE=public
       - MINIO_ROOT_PASSWORD=supersecret
       - MINIO_ROOT_USER=mimir
     image: minio/minio:latest

--- a/compose/jsonnet/lib/containers/beyla/main.libsonnet
+++ b/compose/jsonnet/lib/containers/beyla/main.libsonnet
@@ -6,6 +6,7 @@ local images = import '../images.libsonnet';
     local root = self,
     name:: name,
     port:: port,
+    metrics_port:: root.port,
     service: {
       image: images.beyla,
       container_name: root.name,

--- a/compose/jsonnet/lib/containers/generic/main.libsonnet
+++ b/compose/jsonnet/lib/containers/generic/main.libsonnet
@@ -4,6 +4,7 @@
     local root = self,
     name:: name,
     port:: port,
+    // metrics_port:: root.port,
     service: {
       container_name: root.name,
       ports:

--- a/compose/jsonnet/lib/containers/grafana/main.libsonnet
+++ b/compose/jsonnet/lib/containers/grafana/main.libsonnet
@@ -11,6 +11,7 @@ local images = import '../images.libsonnet';
     local root = self,
     name:: name,
     port:: port,
+    metrics_port:: root.port,
     config_name:: root.name + '_config',
     service: {
       image: images.grafana,

--- a/compose/jsonnet/lib/containers/loki/main.libsonnet
+++ b/compose/jsonnet/lib/containers/loki/main.libsonnet
@@ -6,6 +6,7 @@ local images = import '../images.libsonnet';
     local root = self,
     name:: name,
     port:: port,
+    metrics_port:: root.port,
     config_name:: root.name + '_config',
     service: {
       image: images.loki,

--- a/compose/jsonnet/lib/containers/mimir/main.libsonnet
+++ b/compose/jsonnet/lib/containers/mimir/main.libsonnet
@@ -6,6 +6,7 @@ local images = import '../images.libsonnet';
     local root = self,
     name:: name,
     port:: port,
+    metrics_port:: root.port,
     config_name:: root.name + '_config',
     service: {
       image: images.mimir,

--- a/compose/jsonnet/lib/containers/minio/main.libsonnet
+++ b/compose/jsonnet/lib/containers/minio/main.libsonnet
@@ -6,6 +6,8 @@ local images = import '../images.libsonnet';
     local root = self,
     name:: name,
     port:: port,
+    metrics_port:: root.port,
+    metrics_path:: '/minio/v2/metrics/bucket',
     service: {
       image: images.minio,
       container_name: root.name,
@@ -15,6 +17,7 @@ local images = import '../images.libsonnet';
       _environment:: {
         MINIO_ROOT_USER: 'admin',
         MINIO_ROOT_PASSWORD: 'supersecret',
+        MINIO_PROMETHEUS_AUTH_TYPE: 'public',
       },
       environment: [
         '%s=%s' % [kv.key, kv.value]

--- a/compose/jsonnet/lib/containers/promtail/main.libsonnet
+++ b/compose/jsonnet/lib/containers/promtail/main.libsonnet
@@ -9,6 +9,7 @@ local images = import '../images.libsonnet';
     local root = self,
     name:: name,
     port:: port,
+    metrics_port:: root.port,
     config_name:: root.name + '_config',
     service: {
       image: images.promtail,


### PR DESCRIPTION
Signed-off-by: JuanJo Ciarlante <juanjosec@gmail.com>
