### PR TITLE
fix 2024/2024-10-25--Promtail_syslog-Loki-Grafana to use grafana envvars (remove deprecated pluginInit())

### DIFF
--- a/2024/2024-10-25--Promtail_syslog-Loki-Grafana/docker-compose.yml
+++ b/2024/2024-10-25--Promtail_syslog-Loki-Grafana/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_USERS_DEFAULT_THEME=light
+      - GF_INSTALL_PLUGINS=grafana-lokiexplore-app,grafana-exploretraces-app,grafana-pyroscope-app
+      - GF_FEATURE_TOGGLES_ENABLE=flameGraph traceqlSearch traceQLStreaming correlations metricsSummary traceqlEditor traceToMetrics traceToProfiles datatrails
     image: grafana/grafana:11.3.0-ubuntu
     ports:
       - 3000:3000

--- a/2024/2024-10-28--LGTM_stack/compose.jsonnet
+++ b/2024/2024-10-28--LGTM_stack/compose.jsonnet
@@ -25,12 +25,6 @@ local manifest = compose.new({
     c.tempo.new()
     + c.tempo.withVolume()
     + compose.withDependsOn([root.tempo_init]),
-  grafana_plugin_traces_app:
-    c.grafana.initPlugin(
-      root.grafana,
-      'https://storage.googleapis.com/integration-artifacts/grafana-exploretraces-app/grafana-exploretraces-app-latest.zip',
-      'grafana-traces-app'
-    ),
   grafana:
     local datasources = std.objectValues({
       prom: c.grafana.datasource.withPrometheus(root.prometheus, true),

--- a/2024/2024-10-28--LGTM_stack/docker-compose.yml
+++ b/2024/2024-10-28--LGTM_stack/docker-compose.yml
@@ -15,23 +15,11 @@ services:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_USERS_DEFAULT_THEME=light
+      - GF_INSTALL_PLUGINS=grafana-lokiexplore-app,grafana-exploretraces-app,grafana-pyroscope-app
+      - GF_FEATURE_TOGGLES_ENABLE=flameGraph traceqlSearch traceQLStreaming correlations metricsSummary traceqlEditor traceToMetrics traceToProfiles datatrails
     image: grafana/grafana:11.3.0-ubuntu
     ports:
       - 3000:3000
-    volumes:
-      - grafana-storage:/var/lib/grafana
-  grafana-plugin-grafana-traces-app:
-    command: []
-    container_name: grafana-plugin-grafana-traces-app
-    entrypoint:
-      - grafana
-      - cli
-      - --pluginUrl=https://storage.googleapis.com/integration-artifacts/grafana-exploretraces-app/grafana-exploretraces-app-latest.zip
-      - plugins
-      - install
-      - grafana-traces-app
-    image: grafana/grafana:11.3.0-ubuntu
-    user: grafana
     volumes:
       - grafana-storage:/var/lib/grafana
   loki:


### PR DESCRIPTION
Signed-off-by: JuanJo Ciarlante <juanjosec@gmail.com>
